### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/compose/Dockerfile.nginx
+++ b/compose/Dockerfile.nginx
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy
+FROM jwilder/nginx-proxy:latest
 
 COPY default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
`jwilder/nginx-proxy` changed recently. This pull request ensures you're using the latest version of the image and changes `jwilder/nginx-proxy` to the latest tag: `latest`

New base image: `jwilder/nginx-proxy:latest`